### PR TITLE
Added slowest test output to RichRunner.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -128,6 +128,9 @@ The test runner provides the following features:
 
 * All other flags from Django's DiscoverRunner continue to work in the normal way.
 
+* If the ``--timing`` flag is provided the slowest 10 tests are outputted at the end of a test run.
+  This increases to the slowest 100 tests if verbosity ``-v`` is also provided with value 2 or greater.
+
 Output Width on CI
 ~~~~~~~~~~~~~~~~~~
 

--- a/src/django_rich/test.py
+++ b/src/django_rich/test.py
@@ -40,8 +40,6 @@ class RichTextTestResult(unittest.TextTestResult):
     # https://github.com/python/typeshed/pull/7340
     showAll: bool
 
-    collectedDurations: list[tuple[TestCase, float]] = []
-
     def __init__(
         self,
         stream: TextIO,
@@ -53,6 +51,7 @@ class RichTextTestResult(unittest.TextTestResult):
             # Get underlying stream from _WritelnDecorator, normally sys.stderr:
             file=self.stream.stream,  # type: ignore [attr-defined]
         )
+        self.collectedDurations: list[tuple[TestCase, float]] = []
 
     def addSuccess(self, test: TestCase) -> None:
         if self.showAll:

--- a/src/django_rich/test.py
+++ b/src/django_rich/test.py
@@ -55,8 +55,10 @@ class RichTextTestResult(unittest.TextTestResult):
 
     def startTest(self, test: TestCase) -> None:
         self._timing_start = time.perf_counter_ns()
+        super().startTest(test)
 
     def stopTest(self, test: TestCase) -> None:
+        super().stopTest(test)
         total = (time.perf_counter_ns() - self._timing_start) / 1e9
         if total >= 0.005:
             item = (total, test)

--- a/src/django_rich/test.py
+++ b/src/django_rich/test.py
@@ -57,7 +57,8 @@ class RichTextTestResult(unittest.TextTestResult):
 
     def stopTest(self, test: TestCase) -> None:
         total = (time.perf_counter_ns() - self._timing_start) / 1e9
-        self.collectedDurations.append((test, total))
+        if total >= 0.005:
+            self.collectedDurations.append((test, total))
 
     def addSuccess(self, test: TestCase) -> None:
         if self.showAll:
@@ -206,8 +207,8 @@ class RichRunner(DiscoverRunner):
                 result.collectedDurations, key=lambda x: x[1], reverse=True
             )
             by_time = by_time[:amount_to_print]
-            for func_name, timing in by_time:
+            for test, timing in by_time:
                 result.console.print(
-                    f"[bold yellow]{float(timing):.3f}s[/bold yellow] {func_name}"
+                    f"[bold yellow]{float(timing):.3f}s[/bold yellow] {test}"
                 )
         return len(result.failures) + len(result.errors)


### PR DESCRIPTION
Hi Adam -- me again 😄 

So there's a few design choices I've made.

The first is in the output we can give. For simplicity the test timings will only be output at the end of the test run. The cPython patch would allow them to be inlined when running verbose mode but as far as I can tell that would require folk to use a custom `TestCase`. That breaks the simplicity of "add a setting" to get up and running. 

The second is how you enable it. There's various options, I've currently gone with pass in `--timing` to get it to output, and if verbosity is increased then you get more tests. There's more complex options e.g. add a new flag e.g. `--duration` and allow it to pass in a value, but that adds complexity especially if this could make it's way into Django core one day. Another option I considered was to always output the slowest tests (we're capturing it anyway). 

I am hoping this is a better quality patch at the first pass than last time. I'm hopeful to see the magic green tick shortly. (I suspect Django 2.2 may have something to say about that). 

Ah, finally I think there's a few missing items in typeshed so a number of `#ignores` dotted about. 


![image](https://user-images.githubusercontent.com/39445562/156246313-f5bf2207-6820-49fc-9dbf-cc2ecbbf3b5e.png)

p.s. that regression test is slow 🕵️ 