### PR TITLE
Set minimum width of test runner console to 120 characters

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,8 @@
 History
 =======
 
+* Set minimum width of test runner console to 120 characters, to avoid “squeezed” output on CI systems.
+
 1.2.0 (2022-02-25)
 ------------------
 

--- a/README.rst
+++ b/README.rst
@@ -124,6 +124,9 @@ The test runner provides the following features:
   This displays the source code and local values per frame.
   Each frame also shows the filename and line number, and on many terminals you can click the link to jump to the file at that position.
 
+* The minimum output width is 120 characters, in order to avoid “squeezing” tracebacks and other output.
+  This helps keep output readable on CI systems where Rich would normally use a width of 80 characters.
+
 * Output is also colourized when using the ``--debug-sql`` and ``--pdb`` flags.
 
 * All other flags from Django's DiscoverRunner continue to work in the normal way.

--- a/src/django_rich/test.py
+++ b/src/django_rich/test.py
@@ -49,6 +49,8 @@ class RichTextTestResult(unittest.TextTestResult):
             # Get underlying stream from _WritelnDecorator, normally sys.stderr:
             file=self.stream.stream,  # type: ignore [attr-defined]
         )
+        if self.console.width < 120:
+            self.console.width = 120
 
     def addSuccess(self, test: TestCase) -> None:
         if self.showAll:

--- a/tests/test_test.py
+++ b/tests/test_test.py
@@ -96,9 +96,9 @@ class TestRunnerTests(SimpleTestCase):
         assert result.returncode == 1
         assert result.stderr.splitlines()[:6] == [
             "E",
-            "─" * 80,
+            "─" * 120,
             "ERROR: does_not_exist (unittest.loader._FailedTest)",
-            "─" * 80,
+            "─" * 120,
             "ImportError: Failed to import test module: does_not_exist",
             "Traceback (most recent call last):",
         ]
@@ -131,7 +131,7 @@ class TestRunnerTests(SimpleTestCase):
         result = self.run_test("-v", "0", f"{__name__}.ExampleTests.test_error")
         assert result.returncode == 1
         assert result.stderr.splitlines()[:2] == [
-            "─" * 80,
+            "─" * 120,
             "ERROR: test_error (tests.test_test.ExampleTests)",
         ]
         assert "─ locals ─" in result.stderr
@@ -141,7 +141,7 @@ class TestRunnerTests(SimpleTestCase):
         assert result.returncode == 1
         assert result.stderr.splitlines()[1:4] == [
             "E",
-            "─" * 80,
+            "─" * 120,
             "ERROR: test_error (tests.test_test.ExampleTests)",
         ]
         assert "─ locals ─" in result.stderr
@@ -152,7 +152,7 @@ class TestRunnerTests(SimpleTestCase):
         assert result.stderr.splitlines()[1:5] == [
             "test_error (tests.test_test.ExampleTests) ... ERROR",
             "",
-            "─" * 80,
+            "─" * 120,
             "ERROR: test_error (tests.test_test.ExampleTests)",
         ]
         assert "─ locals ─" in result.stderr
@@ -161,7 +161,7 @@ class TestRunnerTests(SimpleTestCase):
         result = self.run_test("-v", "0", f"{__name__}.ExampleTests.test_failure")
         assert result.returncode == 1
         assert result.stderr.splitlines()[:2] == [
-            "─" * 80,
+            "─" * 120,
             "FAIL: test_failure (tests.test_test.ExampleTests)",
         ]
         assert "─ locals ─" in result.stderr
@@ -171,7 +171,7 @@ class TestRunnerTests(SimpleTestCase):
         assert result.returncode == 1
         assert result.stderr.splitlines()[1:4] == [
             "F",
-            "─" * 80,
+            "─" * 120,
             "FAIL: test_failure (tests.test_test.ExampleTests)",
         ]
         assert "─ locals ─" in result.stderr
@@ -182,7 +182,7 @@ class TestRunnerTests(SimpleTestCase):
         assert result.stderr.splitlines()[1:5] == [
             "test_failure (tests.test_test.ExampleTests) ... FAIL",
             "",
-            "─" * 80,
+            "─" * 120,
             "FAIL: test_failure (tests.test_test.ExampleTests)",
         ]
         assert "─ locals ─" in result.stderr
@@ -286,7 +286,7 @@ class TestRunnerTests(SimpleTestCase):
         assert lines[-10:-4] == [
             "AssertionError: False is not true",
             "",
-            "─" * 80,
+            "─" * 120,
             sql_line,
             "",
             "-" * 70,


### PR DESCRIPTION
I found I needed this on a client project, and I figure it will affect most projects.