### PR TITLE
Move from isort to reorder-python-imports

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,10 +28,16 @@ repos:
   - id: blacken-docs
     additional_dependencies:
     - black==22.10.0
-- repo: https://github.com/pycqa/isort
-  rev: 5.10.1
+- repo: https://github.com/asottile/reorder_python_imports
+  rev: v3.9.0
   hooks:
-  - id: isort
+  - id: reorder-python-imports
+    args:
+    - --py37-plus
+    - --application-directories
+    - .:example:src
+    - --add-import
+    - 'from __future__ import annotations'
 - repo: https://github.com/PyCQA/flake8
   rev: 5.0.4
   hooks:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,10 +5,6 @@ build-backend = "setuptools.build_meta"
 [tool.black]
 target-version = ['py37']
 
-[tool.isort]
-profile = "black"
-add_imports = "from __future__ import annotations"
-
 [tool.mypy]
 mypy_path = "src/"
 show_error_codes = true

--- a/src/django_rich/management.py
+++ b/src/django_rich/management.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
 import sys
-from typing import Any, TextIO
+from typing import Any
+from typing import TextIO
 
-from django.core.management import BaseCommand, CommandError
+from django.core.management import BaseCommand
+from django.core.management import CommandError
 from rich.console import Console
 
 

--- a/src/django_rich/test.py
+++ b/src/django_rich/test.py
@@ -4,16 +4,20 @@ import io
 import sys
 import unittest
 from types import TracebackType
-from typing import Iterable, TextIO, Tuple, Type, Union
+from typing import Iterable
+from typing import TextIO
+from typing import Tuple
+from typing import Type
+from typing import Union
 from unittest.case import TestCase
-from unittest.result import STDERR_LINE, STDOUT_LINE, failfast
+from unittest.result import failfast
+from unittest.result import STDERR_LINE
+from unittest.result import STDOUT_LINE
 
 from django.test import testcases
-from django.test.runner import (  # type: ignore [attr-defined]
-    DebugSQLTextTestResult,
-    DiscoverRunner,
-    PDBDebugResult,
-)
+from django.test.runner import DebugSQLTextTestResult
+from django.test.runner import DiscoverRunner
+from django.test.runner import PDBDebugResult  # type: ignore [attr-defined]
 from rich.color import Color
 from rich.console import Console
 from rich.rule import Rule

--- a/tests/test_management.py
+++ b/tests/test_management.py
@@ -1,12 +1,16 @@
 from __future__ import annotations
 
 from functools import partial
-from inspect import Parameter, Signature, signature
+from inspect import Parameter
+from inspect import Signature
+from inspect import signature
 from io import StringIO
 from unittest import mock
 
 import pytest
-from django.core.management import BaseCommand, CommandError, call_command
+from django.core.management import BaseCommand
+from django.core.management import call_command
+from django.core.management import CommandError
 from django.test import SimpleTestCase
 from rich.console import Console
 

--- a/tests/test_test.py
+++ b/tests/test_test.py
@@ -4,14 +4,14 @@ import os
 import re
 import subprocess
 import sys
-import unittest
 import unittest.case
 from pathlib import Path
 
 import django
 import pytest
 from django.db import connection
-from django.test import SimpleTestCase, TestCase
+from django.test import SimpleTestCase
+from django.test import TestCase
 
 
 @pytest.mark.skip(reason="Run below via Django unittest subprocess.")


### PR DESCRIPTION
It’s [way faster](https://twitter.com/codewithanthony/status/1553034384206438401) and its one-import-per-line style prevents merge conflicts.
