### PR TITLE
Fix failing tests if the TERM variable is set to unknown

### DIFF
--- a/tests/test_management.py
+++ b/tests/test_management.py
@@ -5,6 +5,7 @@ from inspect import Parameter
 from inspect import Signature
 from inspect import signature
 from io import StringIO
+import os
 from unittest import mock
 
 import pytest
@@ -32,6 +33,9 @@ class FakeTtyStringIO(StringIO):
         return True
 
 
+# python rich will disable color/style if TERM is set to "unknown" or "dumb"
+# https://rich.readthedocs.io/en/stable/console.html?highlight=unknown#environment-variables
+@mock.patch.dict(os.environ, TERM="")
 class RichCommandTests(SimpleTestCase):
     def test_init_signature(self):
         rc_signature = strip_annotations(signature(RichCommand.__init__))


### PR DESCRIPTION
When running the test-suite with `TERM=unknown`, the tests fail because the generated output is not "rich".

This happens because python rich will disable color and style if the `TERM` variable is set to either `unknown` or `dumb` [1]

This patch monkey-patches the environment to make the test suite insensitive to the `TERM` variable.

[1] https://rich.readthedocs.io/en/stable/console.html?highlight=unknown#environment-variables

Signed-off-by: Olivier Gayot <olivier.gayot@canonical.com>