### PR TITLE
Add typos tool to pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,6 +16,18 @@ repos:
   - id: check-toml
   - id: end-of-file-fixer
   - id: trailing-whitespace
+- repo: https://github.com/crate-ci/typos
+  rev: 6cb49915af2e93e61f5f0d0a82216e28ad5c7c18  # frozen: v1
+  hooks:
+  - id: typos
+    exclude: |
+      (?x)^(
+        .*\.min\.css
+        |.*\.min\.js
+        |.*\.css\.map
+        |.*\.js\.map
+        |.*\.svg
+      )$
 - repo: https://github.com/tox-dev/pyproject-fmt
   rev: 57b6ff7bf72affdd12c7f3fd6de761ba18a33b3a  # frozen: v2.5.1
   hooks:

--- a/.typos.toml
+++ b/.typos.toml
@@ -1,0 +1,10 @@
+# Configuration file for 'typos' tool
+# https://github.com/crate-ci/typos
+
+[default]
+extend-ignore-re = [
+  # Single line ignore comments
+  "(?Rm)^.*(#|//)\\s*typos: ignore$",
+  # Multi-line ignore comments
+  "(?s)(#|//)\\s*typos: off.*?\\n\\s*(#|//)\\s*typos: on"
+]

--- a/tests/test_test.py
+++ b/tests/test_test.py
@@ -589,7 +589,7 @@ class TestRunnerTests(SimpleTestCase):
     @durations_test
     def test_durations_upstream_source(self):
         # RichTestRunner completely replaces _printDurations(), so check the
-        # overriden function for changes that may need copying in.
+        # overridden function for changes that may need copying in.
         source = dedent(
             inspect.getsource(
                 unittest.TextTestRunner._printDurations,  # type: ignore[attr-defined]
@@ -750,7 +750,7 @@ class TestRunnerTests(SimpleTestCase):
     @sub_test_test
     def test_subtest_upstream_source(self):
         # RichTextTestResult completely replaces _addSubTest(), so check the
-        # overriden function for changes that may need copying in.
+        # overridden function for changes that may need copying in.
         source = dedent(
             inspect.getsource(
                 unittest.TextTestResult.addSubTest,
@@ -779,7 +779,7 @@ class TestRunnerTests(SimpleTestCase):
     @sub_test_test
     def test_write_status_upstream_source(self):
         # RichTextTestResult completely replaces _write_status(), so check the
-        # overriden function for changes that may need copying in.
+        # overridden function for changes that may need copying in.
         source = dedent(
             inspect.getsource(
                 unittest.TextTestResult._write_status,  # type: ignore[attr-defined]


### PR DESCRIPTION
This tool corrects common misspellings in all kinds of text files.
