### PR TITLE
Make tracebacks use the full terminal width

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,10 @@ Unreleased
 
 * Support Django 6.0.
 
+* Make tracebacks use the full terminal width.
+
+  Thanks to Sébastien Corbin for the report in `Issue #240 <https://github.com/adamchainz/django-rich/issues/240>`__.
+
 2.1.0 (2025-09-09)
 ------------------
 

--- a/src/django_rich/test.py
+++ b/src/django_rich/test.py
@@ -170,9 +170,14 @@ class RichTextTestResult(unittest.TextTestResult):
         if exctype is not None:  # pragma: no branch  # can't work when this isn't true
             assert value is not None
             extract = Traceback.extract(exctype, value, tb, show_locals=True)
-            tb_e = Traceback(extract, suppress=[unittest, testcases])
             with self.console.capture() as capture:
-                self.console.print(tb_e)
+                self.console.print(
+                    Traceback(
+                        extract,
+                        suppress=[unittest, testcases],
+                        width=self.console.width,
+                    )
+                )
             msgLines.append(capture.get())
 
         if self.buffer:


### PR DESCRIPTION
Fixes https://github.com/adamchainz/django-rich/issues/240#issuecomment-2736150363

Manually tested, because the unit tests use a fixed small width which `Traceback` already used. Ran `uv sync --group django60 --group test`, activated the venv, and ran `DJANGO_SETTINGS_MODULE=tests.settings python -m django test tests.test_test.ExampleTests.test_failure`.

Before:

<img width="2000" height="466" alt="Xnapper-2025-09-18-12 15 29" src="https://github.com/user-attachments/assets/3931310c-a619-4161-9b5c-e82c69099d6e" />

After:

<img width="2000" height="390" alt="Xnapper-2025-09-18-12 15 35" src="https://github.com/user-attachments/assets/35216f93-07fc-41e1-96bd-d45e3121ffcf" />

Rich shunts the locals to the side on wide screens, saving a bunch of vertical space!

Cheers @sebcorbin